### PR TITLE
Feature 29

### DIFF
--- a/lib/appClient.js
+++ b/lib/appClient.js
@@ -6,7 +6,7 @@ const appClient = {};
 /*
  * Initialise Connection to NATS
  * Init/start Service manager */
-appClient.init = async function (config) {
+appClient.init = async function (appConfig, natsConfig) {
 	/*
 	 * TODO
 	 * Decide upon args for this function
@@ -14,7 +14,7 @@ appClient.init = async function (config) {
 
 	/*
 	 * TODO
-	 * Where will the validity of this config checked?
+	 * Where will the validity of this natsConfig checked?
 	 * Here or down stream?
 	 * design decision */
 
@@ -24,8 +24,8 @@ appClient.init = async function (config) {
 			 * TODO
 			 * Passing confi transparently
 			 * do proper handling */
-			await natsIface.init ();
-			await serviceManager.init (config);
+			await natsIface.init (natsConfig);
+			await serviceManager.init (appConfig, natsConfig);
 		}
 		catch (err) {
 			log.error ({err : err}, 'appClient init error');

--- a/lib/appClient.js
+++ b/lib/appClient.js
@@ -25,7 +25,7 @@ appClient.init = async function (appConfig, natsConfig) {
 			 * Passing confi transparently
 			 * do proper handling */
 			await natsIface.init (natsConfig);
-			await serviceManager.init (appConfig, natsConfig);
+			await serviceManager.init (appConfig);
 		}
 		catch (err) {
 			log.error ({err : err}, 'appClient init error');

--- a/lib/nats-iface.js
+++ b/lib/nats-iface.js
@@ -1,13 +1,13 @@
 var nats     = require ('./nats');
 
-var m = {};
+var __module = {};
 
-m.init = function  (options) {
+__module.init = function  (natsConfig) {
 	/* returns a promise to nats connection */
-	return nats.connect (options);
+	return nats.connect (natsConfig);
 };
 
-m.open_channel = function (channel, callback) {
+__module.open_channel = function (channel, callback) {
 	var sid = nats.subscribe (channel, function (_msg_str, reply_to) {
 		var msg;
 
@@ -26,15 +26,15 @@ m.open_channel = function (channel, callback) {
 	return sid;
 };
 
-m.reply = function (channel, msg) {
+__module.reply = function (channel, msg) {
 	nats.publish (channel, JSON.stringify (msg));
 };
 
-m.send = m.reply;
+__module.send = __module.reply;
 
-m.request = function (channel, msg, options, timeout) {
+__module.request = function (channel, msg, options, timeout) {
 	/* NOT YET IMPLEMENTED */
 };
 
 
-module.exports = m;
+module.exports = __module;

--- a/lib/serviceAnnouncer.js
+++ b/lib/serviceAnnouncer.js
@@ -16,7 +16,7 @@ var beacon_interval = 15 * 1000;
 let conf = {};
 
 serviceAnnouncer.init = function (serviceConfig) {
-	return new Promise (function (resolve, reject) {
+	return new Promise (function (resolve/*, reject*/) {
 
 		/*
 		 * TODO
@@ -88,7 +88,7 @@ serviceAnnouncer.service_demand = function (__payload) {
 serviceAnnouncer.deinit = function () {
 	/*
 	 * send service unavailable request over nats */
-	return new Promise (function (resolve, reject) {
+	return new Promise (function (resolve/*, reject*/) {
 
 		serviceAnnouncer.send('down');
 

--- a/lib/serviceAnnouncer.js
+++ b/lib/serviceAnnouncer.js
@@ -15,13 +15,17 @@ var subject = {
 var beacon_interval = 15 * 1000;
 let conf = {};
 
-serviceAnnouncer.init = function (config) {
+serviceAnnouncer.init = function (serviceConfig) {
 	return new Promise (function (resolve, reject) {
 
 		/*
 		 * TODO
-		 * needs proper config handling */
-		conf = config;
+		 * needs proper serviceConfig handling */
+		conf = serviceConfig;
+
+		/*
+		 * Add namesapce to channel names in case it is sent from upstream */
+		addNamespace ();
 
 		natsiface.open_channel (subject.pull, parse_msg);
 		serviceAnnouncer.send('active');
@@ -91,6 +95,14 @@ serviceAnnouncer.deinit = function () {
 		resolve ();
 	});
 };
+
+function addNamespace () {
+	if (!conf.namespace)
+		return;
+
+	subject.discovery = `${conf.namespace}.${subject.discovery}`;
+	subject.pull      = `${conf.namespace}.${subject.pull}`;
+}
 
 function srv_msg (state) {
 	this.header={

--- a/lib/serviceClient.js
+++ b/lib/serviceClient.js
@@ -6,7 +6,7 @@ const serviceClient    = {};
 /*
  * Initialise Connection to NATS
  * Init/start Service manager */
-serviceClient.init = async function (config) {
+serviceClient.init = async function (serviceConfig, natsConfig) {
 	/*
 	 * TODO
 	 * Decide upon args for this function
@@ -14,7 +14,7 @@ serviceClient.init = async function (config) {
 
 	/*
 	 * TODO
-	 * Where will the validity of this config checked?
+	 * Where will the validity of this serviceConfig checked?
 	 * Here or down stream?
 	 * design decision */
 
@@ -24,8 +24,8 @@ serviceClient.init = async function (config) {
 			 * TODO
 			 * Passing confi transparently
 			 * do proper handling */
-			await natsIface.init ();
-			await serviceAnnouncer.init (config);
+			await natsIface.init (natsConfig);
+			await serviceAnnouncer.init (serviceConfig);
 		}
 		catch (err) {
 			log.error ({err : err}, 'serviceClient init error');

--- a/lib/serviceManager.js
+++ b/lib/serviceManager.js
@@ -9,6 +9,13 @@ var map     = {};
 var cache   = {};
 var beacon_interval = 15 * 1000;
 
+/*
+ * these are defaults
+ * can change during at executio time 
+ * TODO
+ * Maybe unify all these defaults in some config file
+ * fetch them during init,  so that each isntance has a common source
+ * but they can modify it at runtime */
 var subject = {
 	discovery : 'service.discovery',
 	pull      : 'service.pull'
@@ -22,9 +29,13 @@ let conf = {};
  * and a final conf should be created by using defalt conf
  * and overwriting with passed config's mandatories 
  * Config flow is unclean as of now */
-serviceManager.init = function (config) {
+serviceManager.init = function (appConfig, natsConfig) {
 	return new Promise (function (resolve, reject) {
-		conf   = config;
+		conf   = appConfig;
+
+		/*
+		 * Modify channel names according to namespace, if it is recieved from upstream */
+		addNamespace ();
 
 		natsiface.open_channel (subject.discovery, parse_msg);
 		serviceManager.ask ();
@@ -241,6 +252,14 @@ function prune (s_name) {
 	 * Actual delete entries `*/
 	for (let i = 0 ; i < delete_these.length; i++) 
 		beacon_down (map[s_name][delete_these[i]], 'timely pruning (either too many failure or too many missed pings)');
+}
+
+function addNamespace () {
+	if (!conf.namespace)
+		return;
+
+	subject.discovery = `${conf.namespace}.${subject.discovery}`;
+	subject.pull      = `${conf.namespace}.${subject.pull}`;
 }
 
 /*

--- a/lib/serviceManager.js
+++ b/lib/serviceManager.js
@@ -29,8 +29,8 @@ let conf = {};
  * and a final conf should be created by using defalt conf
  * and overwriting with passed config's mandatories 
  * Config flow is unclean as of now */
-serviceManager.init = function (appConfig, natsConfig) {
-	return new Promise (function (resolve, reject) {
+serviceManager.init = function (appConfig) {
+	return new Promise (function (resolve/*, reject*/) {
 		conf   = appConfig;
 
 		/*

--- a/test/app-example/app.example.js
+++ b/test/app-example/app.example.js
@@ -3,7 +3,10 @@ const log       = require ('../../lib/log').child ({module : 'test/app-example/a
 
 async function main () {
 	try {
-		await appClient.init ({name : 'exampleApp'});
+		await appClient.init ({
+			name : 'exampleApp',
+			namespace : 'namespace01'
+		});
 	}
 	catch (err) {
 		log.error ({err : err}, 'appClient init error');

--- a/test/service-example/service.example.js
+++ b/test/service-example/service.example.js
@@ -17,7 +17,8 @@ async function main (port) {
 		await serviceClient.init ({
 			id   : 'exampleService-01',
 			name : 'exampleService',
-			port : port
+			port : port,
+			namespace : 'namespace01'
 		});
 	}
 	catch (err) {


### PR DESCRIPTION
Nats does not have any native "__namespace__" handling on their side of things.
To have different messaging spaces, I simply modified default channel names with `namespace` field received from upstream, hence creating specific channels.

Whats done - Commit messages have that covered.